### PR TITLE
Support section-wise loading and `abs64`

### DIFF
--- a/include/fle.hpp
+++ b/include/fle.hpp
@@ -12,6 +12,7 @@ using json = nlohmann::ordered_json;
 enum class RelocationType {
     R_X86_64_32, // 32位绝对寻址
     R_X86_64_PC32, // 32位相对寻址
+    R_X86_64_64, // 64位绝对寻址
 };
 
 // 重定位项

--- a/include/fle.hpp
+++ b/include/fle.hpp
@@ -44,12 +44,26 @@ struct FLESection {
     std::vector<Relocation> relocs; // Relocations for this section
 };
 
+enum class PHF { // Program Header Flags
+    X = 1, // 可执行
+    W = 2, // 可写
+    R = 4 // 可读
+};
+
+struct ProgramHeader {
+    std::string name; // 段名
+    uint64_t vaddr; // 虚拟地址（改用64位）
+    uint32_t size; // 段大小
+    uint32_t flags; // 权限
+};
+
 struct FLEObject {
     std::string name; // object name
     std::string type; // ".obj" or ".exe"
     std::map<std::string, FLESection> sections; // Section name -> section data
     std::vector<Symbol> symbols; // Global symbol table
-    size_t entry = 0; // Entry point (valid only for .exe)
+    std::vector<ProgramHeader> phdrs; // Program headers (for .exe)
+    size_t entry = 0; // Entry point (for .exe)
 };
 
 class FLEWriter {
@@ -83,6 +97,25 @@ public:
     {
         std::ofstream out(filename);
         out << result.dump(4) << std::endl;
+    }
+
+    void write_program_headers(const std::vector<ProgramHeader>& phdrs)
+    {
+        json phdrs_json = json::array();
+        for (const auto& phdr : phdrs) {
+            json phdr_json;
+            phdr_json["name"] = phdr.name;
+            phdr_json["vaddr"] = phdr.vaddr;
+            phdr_json["size"] = phdr.size;
+            phdr_json["flags"] = phdr.flags;
+            phdrs_json.push_back(phdr_json);
+        }
+        result["phdrs"] = phdrs_json;
+    }
+
+    void write_entry(size_t entry)
+    {
+        result["entry"] = entry;
     }
 
 private:

--- a/src/base/cc.cpp
+++ b/src/base/cc.cpp
@@ -93,8 +93,10 @@ json elf_to_fle(const std::string& binary, const std::string& section)
                 std::string reloc_format;
                 if (reloc_type == "R_X86_64_PC32" || reloc_type == "R_X86_64_PLT32") {
                     reloc_format = ".rel"; // 相对重定位
+                } else if (reloc_type == "R_X86_64_64") {
+                    reloc_format = ".abs64"; // 64位绝对重定位
                 } else if (reloc_type == "R_X86_64_32") {
-                    reloc_format = ".abs"; // 绝对重定位
+                    reloc_format = ".abs"; // 32位绝对重定位
                 } else {
                     throw std::runtime_error("Unsupported relocation type: " + reloc_type);
                 }
@@ -102,7 +104,8 @@ json elf_to_fle(const std::string& binary, const std::string& section)
                 // 生成重定位表达式
                 std::stringstream ss;
                 ss << reloc_format << "(" << symbol << ")";
-                relocations[offset] = { 4, ss.str() };
+                size_t size = (reloc_type == "R_X86_64_64") ? 8 : 4;
+                relocations[offset] = { size, ss.str() };
             }
         }
     }

--- a/src/base/exec.cpp
+++ b/src/base/exec.cpp
@@ -14,28 +14,28 @@ void FLE_exec(const FLEObject& obj)
         throw std::runtime_error("File is not an executable FLE.");
     }
 
-    if (obj.sections.find(".load") == obj.sections.end()) {
-        throw std::runtime_error("No .load section found.");
+    // 根据程序头映射内存
+    for (const auto& phdr : obj.phdrs) {
+        void* addr = mmap((void*)phdr.vaddr, phdr.size,
+            (phdr.flags & static_cast<uint32_t>(PHF::R) ? PROT_READ : 0)
+                | (phdr.flags & static_cast<uint32_t>(PHF::W) ? PROT_WRITE : 0)
+                | (phdr.flags & static_cast<uint32_t>(PHF::X) ? PROT_EXEC : 0),
+            MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS, -1, 0);
+
+        if (addr == MAP_FAILED) {
+            throw std::runtime_error(std::string("mmap failed: ") + strerror(errno));
+        }
+
+        // 复制段数据
+        auto it = obj.sections.find(phdr.name);
+        if (it == obj.sections.end()) {
+            throw std::runtime_error("Section not found: " + phdr.name);
+        }
+        memcpy(addr, it->second.data.data(), phdr.size);
     }
 
-    const auto& load_section = obj.sections.at(".load");
-    const auto& data = load_section.data;
-
-    size_t size = data.size();
-    void* mem = mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC,
-        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (mem == MAP_FAILED) {
-        throw std::runtime_error(std::string("mmap failed: ") + strerror(errno));
-    }
-
-    memcpy(mem, data.data(), size);
-
+    // 跳转到入口点
     using FuncType = int (*)();
-    FuncType func = reinterpret_cast<FuncType>(static_cast<uint8_t*>(mem) + obj.entry);
-
-    func(); // NoReturn
-
-    assert(false);
-
-    // munmap(mem, size);
+    FuncType func = reinterpret_cast<FuncType>(obj.entry);
+    func();
 }

--- a/src/base/main.cpp
+++ b/src/base/main.cpp
@@ -23,14 +23,26 @@ FLEObject load_fle(const std::string& file)
     obj.name = get_basename(file);
     obj.type = j["type"].get<std::string>();
 
-    // 如果是可执行文件，读取入口点
-    if (obj.type == ".exe" && j.contains("entry")) {
-        obj.entry = j["entry"].get<size_t>();
+    // 如果是可执行文件，读取入口点和程序头
+    if (obj.type == ".exe") {
+        if (j.contains("entry")) {
+            obj.entry = j["entry"].get<size_t>();
+        }
+        if (j.contains("phdrs")) {
+            for (const auto& phdr_json : j["phdrs"]) {
+                ProgramHeader phdr;
+                phdr.name = phdr_json["name"].get<std::string>();
+                phdr.vaddr = phdr_json["vaddr"].get<uint64_t>();
+                phdr.size = phdr_json["size"].get<uint32_t>();
+                phdr.flags = phdr_json["flags"].get<uint32_t>();
+                obj.phdrs.push_back(phdr);
+            }
+        }
     }
 
     // 处理每个段
     for (auto& [key, value] : j.items()) {
-        if (key == "type" || key == "entry")
+        if (key == "type" || key == "entry" || key == "phdrs")
             continue;
 
         FLESection section;
@@ -165,9 +177,6 @@ int main(int argc, char* argv[])
             for (size_t i = 0; i < args.size(); ++i) {
                 if (args[i] == "-o" && i + 1 < args.size()) {
                     outfile = args[++i];
-                    // if (!outfile.ends_with(".fle")) {
-                    //     outfile += ".fle";
-                    // }
                 } else {
                     input_files.push_back(args[i]);
                 }
@@ -190,32 +199,13 @@ int main(int argc, char* argv[])
                 }
             }
 
-            FLEObject result = FLE_ld(objects);
+            // 链接
+            FLEObject linked_obj = FLE_ld(objects);
 
-            json j;
-            j["type"] = result.type;
-
-            // 只写入 .load 段的数据
-            std::vector<std::string> lines;
-            const auto& load_section = result.sections[".load"];
-
-            // 写入数据
-            for (size_t i = 0; i < load_section.data.size(); i += 16) {
-                std::stringstream ss;
-                ss << "🔢: ";
-                for (size_t j = 0; j < 16 && i + j < load_section.data.size(); ++j) {
-                    ss << std::hex << std::setw(2) << std::setfill('0')
-                       << static_cast<int>(load_section.data[i + j]) << " ";
-                }
-                lines.push_back(ss.str());
-            }
-            j[".load"] = lines;
-
-            // 写入入口点
-            j["entry"] = result.entry;
-
-            std::ofstream out(outfile);
-            out << j.dump(4) << std::endl;
+            // 写入文件
+            FLEWriter writer;
+            FLE_objdump(linked_obj, writer);
+            writer.write_to_file(outfile);
         } else if (tool == "FLE_cc") {
             FLE_cc(args);
         } else if (tool == "FLE_readfle") {

--- a/src/student/ld.cpp
+++ b/src/student/ld.cpp
@@ -147,13 +147,16 @@ FLEObject FLE_ld(const std::vector<FLEObject>& objects)
                 case RelocationType::R_X86_64_PC32:
                     value = symbol_value + reloc.addend - new_reloc.offset - 8;
                     break;
+                case RelocationType::R_X86_64_64:
+                    value = symbol_value + reloc.addend;
+                    break;
                 default:
                     throw std::runtime_error("Unsupported relocation type");
                 }
 
                 // 写入重定位值
-                for (int i = 0; i < 4; ++i) {
-                    // Assume little-endian
+                size_t size = (reloc.type == RelocationType::R_X86_64_64) ? 8 : 4;
+                for (size_t i = 0; i != size; ++i) {
                     load_section.data[new_reloc.offset + i] = (value >> (i * 8)) & 0xFF;
                 }
             }

--- a/src/student/ld.cpp
+++ b/src/student/ld.cpp
@@ -15,28 +15,28 @@ FLEObject FLE_ld(const std::vector<FLEObject>& objects)
     FLEObject result;
     result.type = ".exe";
 
-    // 第一遍：收集所有段并计算偏移
-    // 先收集所有段，按名字分组，使用值而不是指针
-
     using SectionName = std::string;
     struct RawSection {
         std::string file_name;
         FLESection section;
         int offset;
+        int global_offset;
     };
 
     // 1. Collect all sections
     std::map<SectionName, std::vector<RawSection>> section_groups;
     std::vector<SectionName> ordered_section_names;
+
     for (const auto& obj : objects) {
         for (const auto& [section_name, raw_section] : obj.sections) {
-            if (!raw_section.data.size()) {
+            if (!raw_section.data.size())
                 continue;
-            }
+
             section_groups[section_name].push_back({
                 .file_name = obj.name,
                 .section = raw_section,
                 .offset = 0, // To be calculated later
+                .global_offset = 0, // To be calculated later
             });
             if (std::find(ordered_section_names.begin(), ordered_section_names.end(), section_name) == ordered_section_names.end()) {
                 ordered_section_names.push_back(section_name);
@@ -44,38 +44,63 @@ FLEObject FLE_ld(const std::vector<FLEObject>& objects)
         }
     }
 
-    // 2. Concatenate all sections
-    FLESection load_section;
+    // 2. Merge sections and generate program headers
+
+    uint64_t section_vaddr = 0;
+    constexpr uint64_t BASE_VADDR = 0x400000;
+    constexpr uint64_t PAGE_SIZE = 0x1000;
+
     for (auto name : ordered_section_names) {
+        std::cout << "\nMerging section: " << name << std::endl;
         auto& sections = section_groups[name];
-        std::cout << "Processing section group: " << name << std::endl;
+
+        FLESection merged_section;
         for (auto& raw_section : sections) {
-            std::cout << "Processing section: " << name << " from " << raw_section.file_name << std::endl;
-
-            auto& section = raw_section.section;
-            std::cout << "Adding bytes from 0x" << std::hex << std::setfill('0') << std::setw(2)
-                      << static_cast<int>(section.data.front()) << " to 0x"
-                      << std::hex << std::setfill('0') << std::setw(2)
-                      << static_cast<int>(section.data.back())
-                      << " into " << std::dec << load_section.data.size() << std::endl;
-
-            raw_section.offset = load_section.data.size();
-
-            load_section.data.insert(load_section.data.end(),
-                section.data.begin(), section.data.end());
+            raw_section.offset = merged_section.data.size();
+            raw_section.global_offset = section_vaddr + merged_section.data.size();
+            merged_section.data.insert(merged_section.data.end(),
+                raw_section.section.data.begin(), raw_section.section.data.end());
         }
+
+        uint32_t flags = 0;
+        if (name == ".text" || name.starts_with(".text.")) {
+            flags = static_cast<uint32_t>(PHF::R) | static_cast<uint32_t>(PHF::X);
+        } else if (name == ".rodata" || name.starts_with(".rodata.")) {
+            flags = static_cast<uint32_t>(PHF::R);
+        } else if (name == ".data" || name.starts_with(".data.")) {
+            flags = static_cast<uint32_t>(PHF::R) | static_cast<uint32_t>(PHF::W);
+        }
+
+        auto section_size = static_cast<uint32_t>(merged_section.data.size());
+        result.phdrs.push_back(ProgramHeader {
+            .name = name,
+            .vaddr = BASE_VADDR + section_vaddr,
+            .size = section_size,
+            .flags = flags });
+
+        result.sections[name] = merged_section;
+        section_vaddr += section_size;
+        section_vaddr = (section_vaddr + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
     }
 
-    // 2. Collect all symbols
-    std::map<std::string, Symbol> global_symbols; // 全局符号表
-    std::map<std::string, size_t> local_symbols; // 局部符号表
+    // 3. Collect all symbols
+    std::map<std::string, Symbol> global_symbols;
+    std::map<std::string, size_t> local_symbols;
 
     auto local_name_prefix = [](std::string_view obj_name, std::string_view sym_name) {
         return std::string(obj_name) + "." + std::string(sym_name);
     };
 
+    std::cout << "\n=== Phase 2: Processing Symbols ===\n";
     for (const auto& obj : objects) {
         for (const auto& sym : obj.symbols) {
+            std::cout << "Symbol: " << sym.name
+                      << " from " << obj.name
+                      << " type=" << (sym.type == SymbolType::LOCAL ? "LOCAL" : sym.type == SymbolType::WEAK ? "WEAK"
+                                                                                                             : "GLOBAL")
+                      << " section=" << sym.section
+                      << " offset=0x" << std::hex << sym.offset << std::dec << std::endl;
+
             // First, find the section
             auto offset_it = section_groups.find(sym.section);
             if (offset_it == section_groups.end()) {
@@ -83,31 +108,28 @@ FLEObject FLE_ld(const std::vector<FLEObject>& objects)
             }
 
             // Second, find the raw section
-            auto raw_section_it = std::find_if(offset_it->second.begin(), offset_it->second.end(), [sym, &obj](const RawSection& section) {
-                return section.file_name == obj.name;
-            });
+            auto raw_section_it = std::find_if(offset_it->second.begin(), offset_it->second.end(),
+                [&](const RawSection& section) { return section.file_name == obj.name; });
             if (raw_section_it == offset_it->second.end()) {
                 throw std::runtime_error("Symbol " + sym.name + " in " + obj.name + " refers to non-existent section " + sym.section);
             }
-            size_t abs_offset = raw_section_it->offset + sym.offset;
+            size_t symbol_global_offset = raw_section_it->global_offset + sym.offset;
 
-            std::cout << "Symbol " << sym.name << " in " << obj.name << " at offset " << abs_offset << std::endl;
+            std::cout << "Symbol " << sym.name << " in " << obj.name << " at offset " << symbol_global_offset << std::endl;
 
             if (sym.type == SymbolType::LOCAL) {
-                local_symbols[local_name_prefix(obj.name, sym.name)] = abs_offset;
+                local_symbols[local_name_prefix(obj.name, sym.name)] = symbol_global_offset;
             } else {
                 auto it = global_symbols.find(sym.name);
                 if (it == global_symbols.end()) {
                     Symbol new_sym = sym;
-                    new_sym.section = ".load";
-                    new_sym.offset = abs_offset;
+                    new_sym.offset = symbol_global_offset;
                     global_symbols[sym.name] = new_sym;
-                } else if (it->second.type == SymbolType::GLOBAL && sym.type == SymbolType::GLOBAL) {
+                } else if (sym.type == SymbolType::GLOBAL && it->second.type == SymbolType::GLOBAL) {
                     throw std::runtime_error("Multiple definition of strong symbol: " + sym.name);
-                } else if (sym.type == SymbolType::GLOBAL || (sym.type == SymbolType::WEAK && it->second.type == SymbolType::WEAK)) {
+                } else if (sym.type == SymbolType::GLOBAL && it->second.type == SymbolType::WEAK) {
                     Symbol new_sym = sym;
-                    new_sym.section = ".load";
-                    new_sym.offset = abs_offset;
+                    new_sym.offset = symbol_global_offset;
                     it->second = new_sym;
                 }
             }
@@ -115,14 +137,13 @@ FLEObject FLE_ld(const std::vector<FLEObject>& objects)
     }
 
     // 第三遍：处理重定位
+    std::cout << "\n=== Phase 3: Processing Relocations ===\n";
     for (const auto& [name, sections] : section_groups) {
         for (const auto& raw_section : sections) {
             auto& section = raw_section.section;
             for (const auto& reloc : section.relocs) {
-                Relocation new_reloc = reloc;
-                new_reloc.offset += raw_section.offset;
+                size_t reloc_global_offset = raw_section.global_offset + reloc.offset;
 
-                // 查找符号值
                 int64_t symbol_value;
                 // First, check if it's a local symbol
                 auto local_it = local_symbols.find(local_name_prefix(raw_section.file_name, reloc.symbol));
@@ -138,26 +159,39 @@ FLEObject FLE_ld(const std::vector<FLEObject>& objects)
                     }
                 }
 
+                std::cout << "\nRelocation in " << name
+                          << " from " << raw_section.file_name << std::endl;
+                std::cout << "  Type: " << (reloc.type == RelocationType::R_X86_64_32 ? "R_X86_64_32" : reloc.type == RelocationType::R_X86_64_PC32 ? "R_X86_64_PC32"
+                                                                                                                                                    : "R_X86_64_64")
+                          << " at offset 0x" << std::hex << reloc_global_offset
+                          << " symbol=" << reloc.symbol
+                          << " addend=" << reloc.addend << std::dec << std::endl;
+
+                std::cout << "  Symbol value: 0x" << std::hex << symbol_value << std::dec << std::endl;
+
                 // 计算重定位值
                 int64_t value;
                 switch (reloc.type) {
                 case RelocationType::R_X86_64_32:
-                    value = symbol_value + reloc.addend;
+                    value = BASE_VADDR + symbol_value + reloc.addend;
                     break;
                 case RelocationType::R_X86_64_PC32:
-                    value = symbol_value + reloc.addend - new_reloc.offset - 8;
+                    value = symbol_value + reloc.addend - reloc_global_offset - 8;
                     break;
                 case RelocationType::R_X86_64_64:
-                    value = symbol_value + reloc.addend;
+                    value = BASE_VADDR + symbol_value + reloc.addend;
                     break;
                 default:
                     throw std::runtime_error("Unsupported relocation type");
                 }
 
+                std::cout << "  Final value: 0x" << std::hex << value << std::dec << std::endl;
+
                 // 写入重定位值
                 size_t size = (reloc.type == RelocationType::R_X86_64_64) ? 8 : 4;
+                size_t reloc_offset = raw_section.offset + reloc.offset;
                 for (size_t i = 0; i != size; ++i) {
-                    load_section.data[new_reloc.offset + i] = (value >> (i * 8)) & 0xFF;
+                    result.sections[name].data[reloc_offset + i] = (value >> (i * 8)) & 0xFF;
                 }
             }
         }
@@ -168,10 +202,11 @@ FLEObject FLE_ld(const std::vector<FLEObject>& objects)
     if (start_it == global_symbols.end()) {
         throw std::runtime_error("No _start symbol found");
     }
-    result.entry = start_it->second.offset;
+    result.entry = BASE_VADDR + start_it->second.offset;
 
-    // 保存结果
-    result.sections[".load"] = load_section;
+    std::cout << "\n=== Phase 4: Finalizing ===\n";
+    std::cout << "Entry point: 0x" << std::hex << result.entry << std::dec << std::endl;
+    std::cout << "Total size: 0x" << std::hex << result.sections[".text"].data.size() << std::dec << " bytes\n";
 
     return result;
 }

--- a/src/student/objdump.cpp
+++ b/src/student/objdump.cpp
@@ -7,7 +7,13 @@ void FLE_objdump(const FLEObject& obj, FLEWriter& writer)
 {
     writer.set_type(obj.type);
 
-    // 处理每个段
+    // 如果是可执行文件，写入程序头和入口点
+    if (obj.type == ".exe") {
+        writer.write_program_headers(obj.phdrs);
+        writer.write_entry(obj.entry);
+    }
+
+    // 写入所有段的内容
     for (const auto& [name, section] : obj.sections) {
         writer.begin_section(name);
 

--- a/tests/cases/5-abs64/ans.out
+++ b/tests/cases/5-abs64/ans.out
@@ -1,0 +1,1 @@
+Hello World! 

--- a/tests/cases/5-abs64/config.toml
+++ b/tests/cases/5-abs64/config.toml
@@ -1,0 +1,41 @@
+[meta]
+name = "64-bit Absolute Relocation Test"
+description = "Test R_X86_64_64 relocation type with global pointer"
+score = 10
+
+[[run]]
+name = "Compile main.c"
+command = "${root_dir}/cc"
+args = [
+    "${test_dir}/main.c",
+    "-o",
+    "${build_dir}/main.o",
+    "-I${common_dir}",
+    "-g",
+    "-Os",
+]
+
+[run.check]
+files = ["${build_dir}/main.fle"]
+
+[[run]]
+name = "Link program"
+command = "${root_dir}/ld"
+args = [
+    "${build_dir}/main.fle",
+    "${common_dir}/minilibc.fle",
+    "-o",
+    "${build_dir}/program",
+]
+
+[run.check]
+files = ["${build_dir}/program"]
+
+[[run]]
+name = "Run program"
+command = "${root_dir}/exec"
+args = ["${build_dir}/program"]
+
+[run.check]
+stdout = "ans.out"
+return_code = 0 

--- a/tests/cases/5-abs64/main.c
+++ b/tests/cases/5-abs64/main.c
@@ -1,0 +1,10 @@
+#include "minilibc.h"
+
+// 全局指针变量，会触发 R_X86_64_64 重定位
+char* global_ptr = "Hello World!\n";
+
+int main()
+{
+    print(global_ptr, NULL);
+    return 0;
+}


### PR DESCRIPTION
- Do not merge all sections into a `.init` section in the executable. Instead, record all `phdrs` (program headers) in the executable, meaning the `vaddr` each section should be loaded to. And also change the linking logic, including entry point calculation (+BASE_ADDR), sections merging, and relocations.
- Support abs64, since now we are actually performing no-pie linking. So the absolute relocation is supported.